### PR TITLE
ci: add workflow_dispatch to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
v2.0.0 of @dashecorp/rig-memory-mcp is in main but never got published to GitHub Packages. The only successful publish run is `5254da7` (2026-04-16 14:21 UTC) which shipped v1.0.0 from pre-rewrite code. PR #2 merged 5 hours later but didn't trigger publish.yml — unclear why.

Adding `workflow_dispatch` so we can manually trigger publishing. Side effect: merging this PR itself re-triggers the push path and publishes v2.0.0.

Required for the memory MCP fix chain: dashecorp/rig-agent-runtime's pods currently have v1.0.0 (SQLite-based) installed globally; they can't get v2.0.0 (Postgres) until it's on the registry.