### PR TITLE
feat: emit memory_* events to Conductor-E on every tool call

### DIFF
--- a/events.js
+++ b/events.js
@@ -1,0 +1,60 @@
+/**
+ * Event emission to Conductor-E.
+ *
+ * Every successful memory tool call mirrors to Conductor-E's /api/events
+ * endpoint so the rig's central event store / dashboards see memory activity
+ * alongside cli_started, token_usage, heartbeat, etc.
+ *
+ * Fire-and-forget: emission failures never break the MCP call. Silent skip
+ * when CONDUCTOR_BASE_URL is unset (local dev / standalone use).
+ *
+ * FUTURE: replace with OTel GenAI span emission once the rig has an OTel
+ * collector deployed (whitepaper observability.md). Until then, the JSON
+ * POST keeps the same payload shape so the migration is lossless.
+ */
+
+const CONDUCTOR_BASE_URL = process.env.CONDUCTOR_BASE_URL || "";
+const AGENT_ROLE = process.env.AGENT_ROLE || "";
+const WRITTEN_BY_AGENT = process.env.WRITTEN_BY_AGENT || AGENT_ROLE;
+const AGENT_ID = process.env.AGENT_ID || WRITTEN_BY_AGENT;
+
+const EMIT_TIMEOUT_MS = 2000;
+
+/**
+ * Emit a memory event to Conductor-E. Non-blocking; errors are logged but swallowed.
+ *
+ * @param {string} type - event type, e.g. "memory_written", "memory_read"
+ * @param {object} payload - event-specific fields (merged with agent identity)
+ */
+export function emitEvent(type, payload = {}) {
+  if (!CONDUCTOR_BASE_URL) return;
+
+  const body = {
+    type,
+    agentId: AGENT_ID,
+    agentRole: AGENT_ROLE,
+    writtenByAgent: WRITTEN_BY_AGENT,
+    timestamp: new Date().toISOString(),
+    ...payload,
+  };
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), EMIT_TIMEOUT_MS);
+
+  fetch(`${CONDUCTOR_BASE_URL}/api/events`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+    signal: ctrl.signal,
+  })
+    .then((r) => {
+      if (!r.ok) {
+        console.error(`[rig-memory] event emit ${type} → ${r.status}`);
+      }
+    })
+    .catch((e) => {
+      // Swallow — never let telemetry break the tool call.
+      console.error(`[rig-memory] event emit ${type} failed: ${e.message}`);
+    })
+    .finally(() => clearTimeout(timer));
+}

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ import {
   compactRepo,
   createSqliteBackend,
 } from "./db.js";
+import { emitEvent } from "./events.js";
 
 // ---------- Config ----------
 
@@ -346,6 +347,17 @@ async function main() {
             embedding,
           });
 
+          emitEvent("memory_written", {
+            memoryId: id,
+            repo,
+            issueId: args.issue_id ?? null,
+            scope: args.scope,
+            kind: args.kind,
+            title: args.title,
+            importance: args.importance ?? 3,
+            embedded: embedding !== null,
+          });
+
           return ok({
             id,
             message: `Memory saved (id: ${id})`,
@@ -365,6 +377,15 @@ async function main() {
             embedding,
           });
 
+          emitEvent("memory_read", {
+            query: args.query,
+            repoFilter: args.repo ?? null,
+            agentRoleFilter: args.agent_role ?? null,
+            issueIdFilter: args.issue_id ?? null,
+            resultCount: rows.length,
+            mode: embedding ? "hybrid" : "text-only",
+          });
+
           return ok({
             memories: rows.map(formatMemory),
             total: rows.length,
@@ -379,6 +400,12 @@ async function main() {
             limit: args.limit ?? 10,
           });
 
+          emitEvent("memory_listed", {
+            repoFilter: args.repo ?? null,
+            agentRoleFilter: args.agent_role ?? null,
+            resultCount: rows.length,
+          });
+
           return ok({
             memories: rows.map(formatMemory),
             total: rows.length,
@@ -387,6 +414,12 @@ async function main() {
 
         case "mark_used": {
           const found = await backend.markUsed(args.memory_id);
+
+          emitEvent("memory_used", {
+            memoryId: args.memory_id,
+            found,
+          });
+
           return ok({ found, memory_id: args.memory_id });
         }
 
@@ -396,6 +429,13 @@ async function main() {
             older_than_days: args.older_than_days ?? 30,
             agent_role: AGENT_ROLE,
             written_by_agent: WRITTEN_BY_AGENT,
+          });
+
+          emitEvent("memory_compacted", {
+            repo: args.repo,
+            olderThanDays: args.older_than_days ?? 30,
+            deleted: result.deleted,
+            summariesCreated: result.summaries_created,
           });
 
           return ok({

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/dashecorp/rig-memory-mcp.git"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MCP memory server for the engineering rig — Postgres+pgvector primary, SQLite fallback",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Every successful memory MCP tool call mirrors as an event in Conductor-E's /api/events. Lands in the same event store as heartbeat, cli_started, token_usage, etc. — dashboards, projections, SSE streams see memory activity without per-agent queries.

## Events emitted

| Tool | Event type | Payload highlights |
|---|---|---|
| write_memory | \`memory_written\` | memoryId, repo, scope, kind, importance, embedded |
| read_memories | \`memory_read\` | query, filters, resultCount, mode |
| list_recent | \`memory_listed\` | filters, resultCount |
| mark_used | \`memory_used\` | memoryId, found |
| compact_repo | \`memory_compacted\` | repo, deleted, summariesCreated |

All include \`agentId\`, \`agentRole\`, \`writtenByAgent\`, \`timestamp\` for attribution.

## Safety

Fire-and-forget: emission runs after the tool response is returned. 2-second timeout via AbortController. Failures log but never break the tool call. Silent skip when \`CONDUCTOR_BASE_URL\` is unset.

## Forward path

Payload shape is intentionally close to OTel GenAI span attributes. When the rig deploys an OTel collector (whitepaper observability.md), \`events.js\` swaps to an OTel span emitter with no protocol churn for consumers.

## Test plan

After merge + publish.yml → v2.1.0 → rig-agent-runtime base rebuild → pod restart:
- [ ] Any Dev-E assignment that writes a memory shows a \`memory_written\` row in \`mt_events\`
- [ ] Stream-consumer's auto-load logs \`memory_read\` events
- [ ] \`write_memory\` from Claude still returns the same ok() JSON (no behavior change for callers)