### PR TITLE
fix: match Conductor-E event schema (PascalCase + uppercase types)

### DIFF
--- a/events.js
+++ b/events.js
@@ -1,16 +1,25 @@
 /**
  * Event emission to Conductor-E.
  *
- * Every successful memory tool call mirrors to Conductor-E's /api/events
- * endpoint so the rig's central event store / dashboards see memory activity
- * alongside cli_started, token_usage, heartbeat, etc.
+ * Mirrors successful memory MCP tool calls as events in Conductor-E's event
+ * store (Marten). Payload shape matches `SubmitEventRequest` in
+ * dashecorp/conductor-e `src/ConductorE.Core/UseCases/SubmitEvent.cs`:
+ * PascalCase fields, UPPER_SNAKE event types.
  *
- * Fire-and-forget: emission failures never break the MCP call. Silent skip
- * when CONDUCTOR_BASE_URL is unset (local dev / standalone use).
+ * Emitted types (all known to SubmitEvent's MapToEvent switch):
+ *   - MEMORY_WRITE     on write_memory
+ *   - MEMORY_READ      on read_memories
+ *   - MEMORY_HIT_USED  on mark_used
+ *
+ * `list_recent` and `compact_repo` have no matching Conductor record type
+ * (yet) — skipped silently. Add them on the Conductor side if we want them.
+ *
+ * Fire-and-forget: emission failures log but never break the MCP call.
+ * Silent skip when CONDUCTOR_BASE_URL is unset (local dev / standalone).
  *
  * FUTURE: replace with OTel GenAI span emission once the rig has an OTel
- * collector deployed (whitepaper observability.md). Until then, the JSON
- * POST keeps the same payload shape so the migration is lossless.
+ * collector deployed (whitepaper observability.md). Payload shape is close
+ * to OTel attributes so the migration is near-lossless.
  */
 
 const CONDUCTOR_BASE_URL = process.env.CONDUCTOR_BASE_URL || "";
@@ -20,23 +29,8 @@ const AGENT_ID = process.env.AGENT_ID || WRITTEN_BY_AGENT;
 
 const EMIT_TIMEOUT_MS = 2000;
 
-/**
- * Emit a memory event to Conductor-E. Non-blocking; errors are logged but swallowed.
- *
- * @param {string} type - event type, e.g. "memory_written", "memory_read"
- * @param {object} payload - event-specific fields (merged with agent identity)
- */
-export function emitEvent(type, payload = {}) {
+function post(body) {
   if (!CONDUCTOR_BASE_URL) return;
-
-  const body = {
-    type,
-    agentId: AGENT_ID,
-    agentRole: AGENT_ROLE,
-    writtenByAgent: WRITTEN_BY_AGENT,
-    timestamp: new Date().toISOString(),
-    ...payload,
-  };
 
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), EMIT_TIMEOUT_MS);
@@ -49,12 +43,57 @@ export function emitEvent(type, payload = {}) {
   })
     .then((r) => {
       if (!r.ok) {
-        console.error(`[rig-memory] event emit ${type} → ${r.status}`);
+        console.error(`[rig-memory] event emit ${body.Type} → ${r.status}`);
       }
     })
     .catch((e) => {
-      // Swallow — never let telemetry break the tool call.
-      console.error(`[rig-memory] event emit ${type} failed: ${e.message}`);
+      console.error(`[rig-memory] event emit ${body.Type} failed: ${e.message}`);
     })
     .finally(() => clearTimeout(timer));
+}
+
+/**
+ * Emitted after a successful write_memory. Conductor record: MemoryWrite.
+ * Required: Repo, IssueNumber, AgentId, Scope, Kind, MemoryId, Tokens.
+ */
+export function emitMemoryWrite({ repo, issueId, scope, kind, memoryId, tokens = 0 }) {
+  post({
+    Type: "MEMORY_WRITE",
+    Repo: repo || "",
+    IssueNumber: issueId ?? 0,
+    AgentId: AGENT_ID,
+    Scope: scope || "",
+    Kind: kind || "",
+    MemoryId: memoryId || "",
+    Tokens: tokens,
+  });
+}
+
+/**
+ * Emitted after a successful read_memories. Conductor record: MemoryRead.
+ * Required: Repo, IssueNumber, AgentId, Query, Hits, TokensLoaded.
+ */
+export function emitMemoryRead({ repo, issueId, query, hits, tokensLoaded = 0 }) {
+  post({
+    Type: "MEMORY_READ",
+    Repo: repo || "",
+    IssueNumber: issueId ?? 0,
+    AgentId: AGENT_ID,
+    Query: query || "",
+    Hits: hits ?? 0,
+    TokensLoaded: tokensLoaded,
+  });
+}
+
+/**
+ * Emitted after a successful mark_used. Conductor record: MemoryHitUsed.
+ * Required: MemoryId, AgentId, UsedInOutput.
+ */
+export function emitMemoryHitUsed({ memoryId, usedInOutput = true }) {
+  post({
+    Type: "MEMORY_HIT_USED",
+    MemoryId: memoryId || "",
+    AgentId: AGENT_ID,
+    UsedInOutput: usedInOutput,
+  });
 }

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ import {
   compactRepo,
   createSqliteBackend,
 } from "./db.js";
-import { emitEvent } from "./events.js";
+import { emitMemoryWrite, emitMemoryRead, emitMemoryHitUsed } from "./events.js";
 
 // ---------- Config ----------
 
@@ -347,15 +347,13 @@ async function main() {
             embedding,
           });
 
-          emitEvent("memory_written", {
-            memoryId: id,
+          emitMemoryWrite({
             repo,
-            issueId: args.issue_id ?? null,
+            issueId: args.issue_id ?? 0,
             scope: args.scope,
             kind: args.kind,
-            title: args.title,
-            importance: args.importance ?? 3,
-            embedded: embedding !== null,
+            memoryId: id,
+            tokens: approxTokens(args.title, args.content),
           });
 
           return ok({
@@ -377,13 +375,12 @@ async function main() {
             embedding,
           });
 
-          emitEvent("memory_read", {
+          emitMemoryRead({
+            repo: args.repo || "",
+            issueId: args.issue_id ?? 0,
             query: args.query,
-            repoFilter: args.repo ?? null,
-            agentRoleFilter: args.agent_role ?? null,
-            issueIdFilter: args.issue_id ?? null,
-            resultCount: rows.length,
-            mode: embedding ? "hybrid" : "text-only",
+            hits: rows.length,
+            tokensLoaded: rows.reduce((n, r) => n + approxTokens(r.title, r.content), 0),
           });
 
           return ok({
@@ -400,11 +397,8 @@ async function main() {
             limit: args.limit ?? 10,
           });
 
-          emitEvent("memory_listed", {
-            repoFilter: args.repo ?? null,
-            agentRoleFilter: args.agent_role ?? null,
-            resultCount: rows.length,
-          });
+          // Conductor-E has no matching event type for list_recent today.
+          // Add a MEMORY_LISTED record there if we want dashboard visibility.
 
           return ok({
             memories: rows.map(formatMemory),
@@ -415,10 +409,12 @@ async function main() {
         case "mark_used": {
           const found = await backend.markUsed(args.memory_id);
 
-          emitEvent("memory_used", {
-            memoryId: args.memory_id,
-            found,
-          });
+          if (found) {
+            emitMemoryHitUsed({
+              memoryId: args.memory_id,
+              usedInOutput: true,
+            });
+          }
 
           return ok({ found, memory_id: args.memory_id });
         }
@@ -431,12 +427,8 @@ async function main() {
             written_by_agent: WRITTEN_BY_AGENT,
           });
 
-          emitEvent("memory_compacted", {
-            repo: args.repo,
-            olderThanDays: args.older_than_days ?? 30,
-            deleted: result.deleted,
-            summariesCreated: result.summaries_created,
-          });
+          // Conductor-E has no MEMORY_COMPACTED record type today — add one there
+          // if compaction activity becomes observability-relevant.
 
           return ok({
             repo: args.repo,
@@ -464,6 +456,15 @@ async function main() {
 }
 
 // ---------- Helpers ----------
+
+/**
+ * Rough token count: ~4 characters ≈ 1 token (OpenAI/Claude tokenizer heuristic).
+ * Used only for telemetry ballpark — exact count doesn't matter.
+ */
+function approxTokens(...parts) {
+  const chars = parts.filter(Boolean).join(" ").length;
+  return Math.ceil(chars / 4);
+}
 
 function ok(data) {
   return {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/dashecorp/rig-memory-mcp.git"
   },
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "MCP memory server for the engineering rig — Postgres+pgvector primary, SQLite fallback",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Retraction of the v2.1.0 payload shape. Conductor-E's SubmitEventRequest uses PascalCase fields and uppercase-underscore types (MEMORY_WRITE, MEMORY_READ, MEMORY_HIT_USED). v2.1.0 sent camelCase `memory_written` etc., so every emit returned 400.

Matches the contract now — verified by reading dashecorp/conductor-e `src/ConductorE.Core/UseCases/SubmitEvent.cs`.

Bumps to v2.1.1.