### PR TITLE
chore: Conductor-E → rig-conductor scrub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ MCP server exposing persistent agent memory backed by Postgres + pgvector. Tools
 ## Conventions
 
 - Embedding model: OpenAI `text-embedding-3-small` (configurable via env).
-- Scope enum: `repo`, `rig`, `session` — keep in sync with Conductor-E event schema.
+- Scope enum: `repo`, `rig`, `session` — keep in sync with rig-conductor event schema.
 - Kind enum: `learning`, `decision`, `error`, `pattern`, `standard`.
 - Importance: 1–5. Hit-count auto-tracked via `mark_used`.
 - Memory promotion candidate: importance ≥ 4 AND hit_count ≥ 5 (see docs-memory-drift-lint research).
@@ -29,4 +29,4 @@ MCP server exposing persistent agent memory backed by Postgres + pgvector. Tools
 - SQLite default path: `$HOME/.rig-memory/memory.db`. Parent directory is created on startup if it doesn't exist.
 - Set `MEMORY_STRICT=true` to make the server exit (rather than fall back) when Postgres auth fails.
 - Embedding calls are fire-and-forget; timeout 2s. Failures logged but not propagated.
-- Event emission to Conductor-E mirrors MEMORY_WRITE / MEMORY_READ / MEMORY_HIT_USED — payload shape in `events.js`.
+- Event emission to rig-conductor mirrors MEMORY_WRITE / MEMORY_READ / MEMORY_HIT_USED — payload shape in `events.js`.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,6 @@ ghcr.io/dashecorp/rig-memory-mcp:latest
 ghcr.io/dashecorp/rig-memory-mcp:sha-<commit>
 ```
 
-> Rig orchestrator renamed conductor-e → rig-conductor on 2026-04-19 (dashecorp/infra#76).
+> Rig orchestrator renamed rig-conductor → rig-conductor on 2026-04-19 (dashecorp/infra#76).
 
 > E2E smoke #2 passed on 2026-04-19 after rig-gitops#105 fixed the stale DB_URL hostname.

--- a/events.js
+++ b/events.js
@@ -1,9 +1,9 @@
 /**
- * Event emission to Conductor-E.
+ * Event emission to rig-conductor.
  *
- * Mirrors successful memory MCP tool calls as events in Conductor-E's event
+ * Mirrors successful memory MCP tool calls as events in rig-conductor's event
  * store (Marten). Payload shape matches `SubmitEventRequest` in
- * dashecorp/conductor-e `src/ConductorE.Core/UseCases/SubmitEvent.cs`:
+ * dashecorp/rig-conductor `src/ConductorE.Core/UseCases/SubmitEvent.cs`:
  * PascalCase fields, UPPER_SNAKE event types.
  *
  * Emitted types (all known to SubmitEvent's MapToEvent switch):

--- a/index.js
+++ b/index.js
@@ -397,7 +397,7 @@ async function main() {
             limit: args.limit ?? 10,
           });
 
-          // Conductor-E has no matching event type for list_recent today.
+          // rig-conductor has no matching event type for list_recent today.
           // Add a MEMORY_LISTED record there if we want dashboard visibility.
 
           return ok({
@@ -427,7 +427,7 @@ async function main() {
             written_by_agent: WRITTEN_BY_AGENT,
           });
 
-          // Conductor-E has no MEMORY_COMPACTED record type today — add one there
+          // rig-conductor has no MEMORY_COMPACTED record type today — add one there
           // if compaction activity becomes observability-relevant.
 
           return ok({


### PR DESCRIPTION
Catch-all rename of prose + identifier refs. Preserves filenames, image paths, agentId, conductor_e DB name, Discord channel label.