### PR TITLE
ci: match review-e-bot[bot] in request-review (fix stalled synchronize re-review)

### DIFF
--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -27,7 +27,14 @@ jobs:
             const action = context.payload.action;
             const pr_author = context.payload.pull_request.user.login;
 
-            if (pr_author === 'review-e-dashecorp') {
+            // Review-E posts reviews as the review-e-bot[bot] GitHub App; the legacy
+            // review-e-dashecorp user account is being retired. Match BOTH so a
+            // CHANGES_REQUESTED from review-e-bot[bot] is detected on synchronize and
+            // the re-review fires (claude-3#745/#746; rig-memory-mcp was not in that
+            // Stig-Johnny sweep). Without this the stale review never clears (issue #25).
+            const REVIEW_E_LOGINS = ['review-e-bot[bot]', 'review-e-dashecorp'];
+
+            if (REVIEW_E_LOGINS.includes(pr_author)) {
               core.setOutput('should_request', 'false');
               core.setOutput('is_rerequest', 'false');
               console.log('PR author is Review-E, skipping');
@@ -46,7 +53,7 @@ jobs:
               );
 
               const reviewEReviews = reviews
-                .filter(r => r.user.login === 'review-e-dashecorp')
+                .filter(r => REVIEW_E_LOGINS.includes(r.user.login))
                 .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at));
 
               if (reviewEReviews.length > 0 && reviewEReviews[0].state === 'CHANGES_REQUESTED') {


### PR DESCRIPTION
Closes #25

## Bug
`request-review.yml` matched only the **retired `review-e-dashecorp`** user in the author-skip (line 30) and the synchronize filter (line 49), but Review-E posts reviews as the **`review-e-bot[bot]`** GitHub App. So on a `synchronize` (a fix push to a PR with a stale `CHANGES_REQUESTED`), the filter found nothing → logged 'no CHANGES_REQUESTED from Review-E' → **never re-requested review**. The stale review never cleared → PRs stalled even after the feedback was addressed.

**Live instance: PR #24** — frontmatter fixed (16c8d03), CI green, MERGEABLE, but stuck because the re-review never fired.

Same bug as **claude-3#745/#746** (swept across the 16 Stig-Johnny repos) — but **dashecorp/rig-memory-mcp wasn't in that sweep**; the conductor repos are unaffected (they route via `.rig-agent.yaml`/ReviewScanService, not this per-repo workflow).

## Fix
`REVIEW_E_LOGINS = ['review-e-bot[bot]', 'review-e-dashecorp']` in the author-skip and the synchronize filter (the canonical claude-3 pattern). YAML validated. CI-only change.

> After this merges, #24 needs one fresh push (synchronize) to re-trigger the now-fixed re-review → Review-E re-reviews the (already-fixed) head → approves → auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)